### PR TITLE
BNW: compliance with Outpost Planner mod

### DIFF
--- a/brave-new-world/scenarios/bnw/control.lua
+++ b/brave-new-world/scenarios/bnw/control.lua
@@ -106,6 +106,9 @@ function itemCountAllowed(name, count)
     elseif name == "droid-selection-tool" then
         -- let users have the command tool for Robot Army mod (but not the pickup tool)
         return count
+    elseif name == "outpost-builder" then
+        -- let users have an outpost planner tool
+        return count
     elseif string.match(name, ".*module.*") then
         -- allow modules
         return count


### PR DESCRIPTION
The user is allowed to have a outpost planner selection tool in the inventory