### PR TITLE
filter search by ingredients, show all results, ingredient button tooltip, search recipe product items entities equipment tiles, version bump

### DIFF
--- a/auto-research/control.lua
+++ b/auto-research/control.lua
@@ -351,6 +351,7 @@ gui = {
         elseif name == "auto_research_search_text" then
             if event.button == defines.mouse_button_type.right then
                 player.gui.top.auto_research_gui.flow.searchflow.auto_research_search_text.text = ""
+                gui.updateSearchResult(player, player.gui.top.auto_research_gui.flow.searchflow.auto_research_search_text.text)
             end
         else
             local prefix, name = string.match(name, "^auto_research_([^-]*)-(.*)$")

--- a/auto-research/info.json
+++ b/auto-research/info.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-research",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "factorio_version": "0.16",
   "title": "Auto Research",
   "author": "canidae",

--- a/auto-research/locale/en/en.cfg
+++ b/auto-research/locale/en/en.cfg
@@ -20,6 +20,10 @@ deprioritized_label=Blacklisted research:
 none=<none>
 search_label=Search:
 search_tooltip=Search for technology or item to queue/blacklist research
+ingredients_filter_search_results=Ingredients filter results
+ingredients_filter_search_results_tooltip=Only show search results that match the allowed ingredient list above
+show_all_search_results=Show all
+show_all_search_results_tooltip=Show all results instead of default limit of 30
 
 [controls]
 auto_research_toggle=Toggle Auto Research GUI


### PR DESCRIPTION
Adds on-by-default ephemeral option to filter tech search results based on the selected ingredients.

Adds off-by-default ephemeral option to show all results instead of just 30.

Adds item name tooltip to the ingredient selection buttons.

Extends search to include not just recipe names but also the names of items produced, and results of placing those items.

Includes commented-out code that would search localised names if that was possible.