### PR TITLE
brave-new-world: Set cursor_ghost when crafting an item

### DIFF
--- a/brave-new-world/scenarios/bnw/control.lua
+++ b/brave-new-world/scenarios/bnw/control.lua
@@ -101,6 +101,7 @@ function inventoryChanged(event)
                 player.cursor_stack.clear()
             end
         end
+        player.cursor_ghost = game.item_prototypes[item.name]
         player.remove_item(item)
     end
     global.players[event.player_index].crafted = {}


### PR DESCRIPTION
Fixed the issue where the crafting menu had no effect. It would be nice to intercept the crafting command beforehand so you don't have to deal with removing crafted items, but this seems to work now.